### PR TITLE
Require Node.js 8, add TypeScript definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,84 @@
+import yes = require('./yes.json');
+import no = require('./no.json');
+
+declare const yesNoWords: {
+	/**
+	Yes like words.
+
+	@example
+	```
+	import yesNoWords = require('yes-no-words');
+
+	yesNoWords.yes;
+	//=> ['Absolutely', 'Ack', …]
+	```
+	*/
+	readonly yes: Readonly<typeof yes>;
+
+	/**
+	No like words.
+
+	@example
+	```
+	import yesNoWords = require('yes-no-words');
+
+	yesNoWords.no;
+	//=> ['Absolutely not', 'Ahhh nah', …]
+	```
+	*/
+	readonly no: Readonly<typeof no>;
+
+	/**
+	Both yes and no like words.
+
+	@example
+	```
+	import yesNoWords = require('yes-no-words');
+
+	yesNoWords.all;
+	//=> ['Absolutely', 'Absolutely not', 'Ack', …]
+	```
+	*/
+	readonly all: Readonly<typeof yes> & Readonly<typeof no>;
+
+	/**
+	Random yes like words.
+
+	@example
+	```
+	import yesNoWords = require('yes-no-words');
+
+	yesNoWords.yesRandom();
+	//=> 'Yisss'
+	```
+	*/
+	yesRandom(): string;
+
+	/**
+	Random no like words.
+
+	@example
+	```
+	import yesNoWords = require('yes-no-words');
+
+	yesNoWords.noRandom();
+	//=> 'Forget it'
+	```
+	*/
+	noRandom(): string;
+
+	/**
+	Random yes or no like words.
+
+	@example
+	```
+	import yesNoWords = require('yes-no-words');
+
+	yesNoWords.allRandom();
+	//=> 'NEIN NEIN NEIN'
+	```
+	*/
+	allRandom(): string;
+};
+
+export = yesNoWords;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,9 @@
+import {expectType} from 'tsd';
+import yesNoWords = require('.');
+
+expectType<readonly string[]>(yesNoWords.yes);
+expectType<readonly string[]>(yesNoWords.no);
+expectType<readonly string[]>(yesNoWords.all);
+expectType<string>(yesNoWords.yesRandom());
+expectType<string>(yesNoWords.noRandom());
+expectType<string>(yesNoWords.allRandom());

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
 		"yes-no": "cli.js"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
+		"index.d.ts",
 		"cli.js",
 		"yes.json",
 		"no.json"
@@ -44,10 +45,16 @@
 	],
 	"dependencies": {
 		"meow": "^5.0.0",
-		"unique-random-array": "^1.0.0"
+		"unique-random-array": "^2.0.0"
 	},
 	"devDependencies": {
-		"ava": "^0.25.0",
-		"xo": "^0.23.0"
+		"ava": "^1.4.1",
+		"tsd": "^0.7.2",
+		"xo": "^0.24.0"
+	},
+	"tsd": {
+		"compilerOptions": {
+			"resolveJsonModule": true
+		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -28,37 +28,37 @@ yesNoWords.yesRandom();
 
 ### .yes
 
-Type: `array`
+Type: `string[]`
 
 Yes like words.
 
 ### .no
 
-Type: `array`
+Type: `string[]`
 
 No like words.
 
 ### .all
 
-Type: `array`
+Type: `string[]`
 
 Both yes and no like words.
 
 ### .yesRandom()
 
-Type: `function`
+Type: `Function`
 
 Random yes like words.
 
 ### .noRandom()
 
-Type: `function`
+Type: `Function`
 
 Random no like words.
 
 ### .allRandom()
 
-Type: `function`
+Type: `Function`
 
 Random yes or no like words.
 


### PR DESCRIPTION
I deliberately didn't manually type the `.json` files here, I've used the `resolveJsonModule` compiler option. I'm not sure whether this is a good solution for users, they'll get `any` for `.yes`, `.no`, and `.all` properties if they don't have this option enabled in their `tsconfig.json`. I think that maintenance-wise this is the way to go.